### PR TITLE
Add CockroachDB Service to Insta-Infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If any data is persisted from the services to carry across sessions, it gets pus
 |--------------------------|---------------|-----------|
 | Change Data Capture      | debezium      | ✅         |
 | Database                 | cassandra     | ✅         |
+| Database                 | cockroachdb   | ✅         |
 | Database                 | elasticsearch | ✅         |
 | Database                 | mariadb       | ✅         |
 | Database                 | mongodb       | ✅         |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,6 +61,23 @@ services:
     ulimits:
       memlock: -1
 
+  # CockroachDB
+  cockroachdb:
+    container_name: "cockroachdb"
+    image: "cockroachdb/cockroach:v22.1.8"
+    platform: "linux/amd64"
+    command: ["start-single-node", "--insecure"]
+    volumes:
+      - "./data/cockroachdb:/cockroach/cockroach-data"
+    ports:
+      - "26257:26257"
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:8080/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   elasticsearch:
     container_name: "elasticsearch"
     image: "docker.elastic.co/elasticsearch/elasticsearch:8.13.4"


### PR DESCRIPTION
This pull request adds a CockroachDB service to the insta-infra Docker Compose configuration. The service is configured to run in single-node mode with the admin UI accessible on port 8080 and the SQL port on 26257. Additionally, the platform is specified as linux/amd64 to ensure compatibility with ARM-based systems such as Apple Silicon (M1/M2).

Changes:

Added cockroachdb service to docker-compose.yml.
Configured cockroachdb to start in single-node mode with the --insecure flag.
Exposed ports 26257 for SQL and 8080 for the admin UI.
Included a volume mount to persist CockroachDB data.
Added a health check to verify the availability of the admin UI.
Specified the platform as linux/amd64 to ensure compatibility with ARM-based hosts.
How to Test:

Run ./run.sh cockroachdb.
Access the CockroachDB admin UI at http://localhost:8080.
Verify that the CockroachDB service is running and accessible.

Note that depending upon how you're connecting you may need to execute something like the following after spinning up the DB:

docker exec -it cockroachdb cockroach sql --insecure --execute="CREATE USER IF NOT EXISTS thomasmcgeehan; CREATE DATABASE IF NOT EXISTS testdb; GRANT ALL ON DATABASE testdb TO thomasmcgeehan;"