### PR TITLE
Add Cockroach DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If any data is persisted from the services to carry across sessions, it gets pus
 |--------------------------|---------------|-----------|
 | Change Data Capture      | debezium      | ✅         |
 | Database                 | cassandra     | ✅         |
+| Database                 | cockroachdb   | ✅         |
 | Database                 | elasticsearch | ✅         |
 | Database                 | mariadb       | ✅         |
 | Database                 | mongodb       | ✅         |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If any data is persisted from the services to carry across sessions, it gets pus
 | Database                 | mariadb       | ✅         |
 | Database                 | mongodb       | ✅         |
 | Database                 | mysql         | ✅         |
+| Database                 | neo4j         | ✅         |
 | Database                 | postgres      | ✅         |
 | Database                 | opensearch    | ❌         |
 | Data Catalog             | marquez       | ✅         |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If any data is persisted from the services to carry across sessions, it gets pus
 | Database                 | mysql         | ✅         |
 | Database                 | neo4j         | ✅         |
 | Database                 | postgres      | ✅         |
-| Database                 | opensearch    | ❌         |
+| Database                 | opensearch    | ✅         |
 | Data Catalog             | marquez       | ✅         |
 | Data Catalog             | amundsen      | ❌         |
 | Data Catalog             | datahub       | ❌         |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -166,6 +166,37 @@ services:
       timeout: 10s
       retries: 5
 
+  # OpenSearch
+  opensearch:
+    container_name: opensearch
+    image: opensearchproject/opensearch:2.5.0
+    environment:
+      - discovery.type=single-node
+      - plugins.security.ssl.http.enabled=false
+      - plugins.security.disabled=true
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - ./data/opensearch:/usr/share/opensearch/data
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+
+  # OpenSearch Dashboards
+  opensearch-dashboards:
+    container_name: opensearch-dashboards
+    image: opensearchproject/opensearch-dashboards:2.5.0
+    environment:
+      - OPENSEARCH_HOSTS=http://opensearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - opensearch
+
   postgres:
     container_name: "postgres"
     image: "postgres:16.3"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -147,24 +147,23 @@ services:
     ports:
       - "3306:3306"
 
-  # Neo4j
-  neo4j:
-    container_name: neo4j
-    image: neo4j:4.4.10
+  postgres:
+    container_name: "postgres"
+    image: "postgres:16.3"
     environment:
-      - NEO4J_AUTH=none
-      - NEO4J_dbms_connector_http_advertised__address=localhost:7474
-      - NEO4J_dbms_connector_bolt_advertised__address=localhost:7687
+      - "POSTGRES_USER=postgres"
+      - "POSTGRES_PASSWORD=postgres"
+      - "PGDATA=/data/postgres"
     volumes:
-      - ./data/neo4j:/data
-    ports:
-      - "7474:7474"
-      - "7687:7687"
+      - "./data/postgres/persist:/data/postgres"
+      - "./data/postgres/my_data.sql:/docker-entrypoint-initdb.d/my_data.sql"
     healthcheck:
-      test: ["CMD-SHELL", "cypher-shell -u neo4j -p test 'RETURN 1' || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: "10s"
+      timeout: "5s"
+      retries: 3
+    ports:
+      - "5432:5432"
 
   # OpenSearch
   opensearch:
@@ -172,7 +171,6 @@ services:
     image: opensearchproject/opensearch:2.5.0
     environment:
       - discovery.type=single-node
-      - plugins.security.ssl.http.enabled=false
       - plugins.security.disabled=true
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -196,24 +194,6 @@ services:
       - "5601:5601"
     depends_on:
       - opensearch
-
-  postgres:
-    container_name: "postgres"
-    image: "postgres:16.3"
-    environment:
-      - "POSTGRES_USER=postgres"
-      - "POSTGRES_PASSWORD=postgres"
-      - "PGDATA=/data/postgres"
-    volumes:
-      - "./data/postgres/persist:/data/postgres"
-      - "./data/postgres/my_data.sql:/docker-entrypoint-initdb.d/my_data.sql"
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
-      interval: "10s"
-      timeout: "5s"
-      retries: 3
-    ports:
-      - "5432:5432"
 
   #data catalog
   marquez-server:
@@ -830,3 +810,4 @@ services:
     depends_on:
       postgres:
         condition: "service_healthy"
+  

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -147,6 +147,25 @@ services:
     ports:
       - "3306:3306"
 
+  # Neo4j
+  neo4j:
+    container_name: neo4j
+    image: neo4j:4.4.10
+    environment:
+      - NEO4J_AUTH=none
+      - NEO4J_dbms_connector_http_advertised__address=localhost:7474
+      - NEO4J_dbms_connector_bolt_advertised__address=localhost:7687
+    volumes:
+      - ./data/neo4j:/data
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p test 'RETURN 1' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
   postgres:
     container_name: "postgres"
     image: "postgres:16.3"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,22 @@ services:
       retries: 3
 
   #database
+  cockroachdb:
+    container_name: "cockroachdb"
+    image: "cockroachdb/cockroach:v22.1.8"
+    platform: "linux/amd64"
+    command: ["start-single-node", "--insecure"]
+    volumes:
+      - "./data/cockroachdb:/cockroach/cockroach-data"
+    ports:
+      - "26257:26257"
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:8080/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   cassandra:
     container_name: "cassandra"
     image: "datacatering/dse-server:6.8.48"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,6 +61,23 @@ services:
     ulimits:
       memlock: -1
 
+  # CockroachDB
+  cockroachdb:
+    container_name: "cockroachdb"
+    image: "cockroachdb/cockroach:v22.1.8"
+    platform: "linux/amd64"
+    command: ["start-single-node", "--insecure"]
+    volumes:
+      - "./data/cockroachdb:/cockroach/cockroach-data"
+    ports:
+      - "26257:26257"
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:8080/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   elasticsearch:
     container_name: "elasticsearch"
     image: "docker.elastic.co/elasticsearch/elasticsearch:8.13.4"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,23 +61,6 @@ services:
     ulimits:
       memlock: -1
 
-  # CockroachDB
-  cockroachdb:
-    container_name: "cockroachdb"
-    image: "cockroachdb/cockroach:v22.1.8"
-    platform: "linux/amd64"
-    command: ["start-single-node", "--insecure"]
-    volumes:
-      - "./data/cockroachdb:/cockroach/cockroach-data"
-    ports:
-      - "26257:26257"
-      - "8080:8080"
-    healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://localhost:8080/ || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   elasticsearch:
     container_name: "elasticsearch"
     image: "docker.elastic.co/elasticsearch/elasticsearch:8.13.4"
@@ -147,6 +130,24 @@ services:
     ports:
       - "3306:3306"
 
+  neo4j:
+    container_name: neo4j
+    image: neo4j:4.4.10
+    environment:
+      - NEO4J_AUTH=none
+      - NEO4J_dbms_connector_http_advertised__address=localhost:7474
+      - NEO4J_dbms_connector_bolt_advertised__address=localhost:7687
+    volumes:
+      - ./data/neo4j:/data
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p test 'RETURN 1' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
   postgres:
     container_name: "postgres"
     image: "postgres:16.3"
@@ -164,36 +165,6 @@ services:
       retries: 3
     ports:
       - "5432:5432"
-
-  # OpenSearch
-  opensearch:
-    container_name: opensearch
-    image: opensearchproject/opensearch:2.5.0
-    environment:
-      - discovery.type=single-node
-      - plugins.security.disabled=true
-      - bootstrap.memory_lock=true
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    volumes:
-      - ./data/opensearch:/usr/share/opensearch/data
-    ports:
-      - "9200:9200"
-      - "9600:9600"
-
-  # OpenSearch Dashboards
-  opensearch-dashboards:
-    container_name: opensearch-dashboards
-    image: opensearchproject/opensearch-dashboards:2.5.0
-    environment:
-      - OPENSEARCH_HOSTS=http://opensearch:9200
-    ports:
-      - "5601:5601"
-    depends_on:
-      - opensearch
 
   #data catalog
   marquez-server:

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,7 @@ connection_commands="
 activemq='/var/lib/artemis-instance/bin/artemis shell --user artemis --password artemis'
 cassandra='cqlsh'
 clickhouse='clickhouse-client'
+cockroachdb='./cockroach sql --insecure'
 doris='mysql -uroot -P9030 -h127.0.0.1'
 duckdb='./duckdb'
 elasticsearch='elasticsearch-sql-cli http://elastic:elasticsearch@localhost:9200'

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 connection_commands="
 activemq='/var/lib/artemis-instance/bin/artemis shell --user artemis --password artemis'
 cassandra='cqlsh'
+cockroachdb='./cockroach sql --insecure'
 clickhouse='clickhouse-client'
 doris='mysql -uroot -P9030 -h127.0.0.1'
 duckdb='./duckdb'
@@ -18,6 +19,7 @@ elasticsearch='elasticsearch-sql-cli http://elastic:elasticsearch@localhost:9200
 mariadb='mariadb --user=user --password=password'
 mongodb-connect='mongosh mongodb://root:root@mongodb'
 mysql='mysql -u root -proot'
+neo4j='cypher-shell -u neo4j -p test'
 postgres='PGPASSWORD=postgres psql -Upostgres'
 prefect-data='bash'
 presto='presto-cli'

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 connection_commands="
 activemq='/var/lib/artemis-instance/bin/artemis shell --user artemis --password artemis'
 cassandra='cqlsh'
-cockroachdb='./cockroach sql --insecure'
 clickhouse='clickhouse-client'
 doris='mysql -uroot -P9030 -h127.0.0.1'
 duckdb='./duckdb'


### PR DESCRIPTION
This PR introduces CockroachDB, including SQL service and Web console support. It also includes a connection command in run.sh.

☁  insta-infra [feature/cockroachdb] ./run.sh cockroachdb                                     
Checking for docker and docker-compose...
Starting up services...
[+] Running 8/8
 ✔ cockroachdb 7 layers [⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                                                  6.2s 
   ✔ d5d2e87c6892 Pull complete                                                                                                                                                                           2.0s 
   ✔ 008dba906bf6 Pull complete                                                                                                                                                                           0.3s 
   ✔ 881d13c40d43 Pull complete                                                                                                                                                                           0.8s 
   ✔ 2da035587f09 Pull complete                                                                                                                                                                           0.6s 
   ✔ 20cbd868d876 Pull complete                                                                                                                                                                           4.2s 
   ✔ 7020f778a7d8 Pull complete                                                                                                                                                                           1.3s 
   ✔ 202b8177354c Pull complete                                                                                                                                                                           2.1s 
[+] Building 0.0s (0/0)                                                                                                                                                                   docker:desktop-linux
[+] Running 2/2
 ✔ Network insta-infra_default  Created                                                                                                                                                                   0.0s 
 ✔ Container cockroachdb        Started                                                                                                                                                                   0.2s 
How to connect:
Service      Container To Container  Host To Container  Container To Host
cockroachdb  cockroachdb:26257       localhost:26257    host.docker.internal:26257
cockroachdb  cockroachdb:8080        localhost:8080     host.docker.internal:8080
☁  insta-infra [feature/cockroachdb] ./run.sh connect cockroachdb
Connecting to cockroachdb...
Welcome to the CockroachDB SQL shell.
All statements must be terminated by a semicolon.
To exit, type: \q.
Server version: CockroachDB CCL v22.1.8 (x86_64-pc-linux-gnu, built 2022/09/29 14:21:51, go1.17.11) (same version as client)
Cluster ID: b4a6c797-9a08-4853-bc02-497892c4f5a9

Enter \? for a brief introduction.
root@:26257/defaultdb> 