### PR TITLE
Add MLflow Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ POSTGRES_USER=my-user POSTGRES_PASSWORD=my-password ./run.sh postgres
 | Job Orchestrator            | airflow       | ✅         |
 | Job Orchestrator            | dagster       | ✅         |
 | Job Orchestrator            | mage-ai       | ✅         |
+| Job Orchestrator            | mlflow        | ✅         |
 | Job Orchestrator            | prefect       | ✅         |
 | Messaging                   | activemq      | ✅         |
 | Messaging                   | kafka         | ✅         |
@@ -148,5 +149,4 @@ POSTGRES_USER=my-user POSTGRES_PASSWORD=my-password ./run.sh postgres
 | Real-time OLAP              | druid         | ✅         |
 | Real-time OLAP              | pinot         | ✅         |
 | Test Data Management        | data-caterer  | ✅         |
-| Workflow                    | temporal      | ✅         | 
-
+| Workflow                    | temporal      | ✅         |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -610,6 +610,17 @@
       - "27017:27017"
     "volumes":
       - "./data/mongodb/persist:/data/db"
+  "mlflow":
+    "container_name": "mlflow"
+    "environment":
+      - "MLFLOW_TRACKING_URI=http://localhost:5001"
+    "image": "ghcr.io/mlflow/mlflow:v2.0.1"
+    "platform": "linux/amd64"
+    "ports":
+      - "5001:5000"
+    "volumes":
+      - "./data/mlflow:/mlflow"
+    "command": "mlflow server --host 0.0.0.0"
   "mysql":
     "command": ["/bin/bash", "-c", "/tmp/scripts/init.sh"]
     "container_name": "mysql-data"


### PR DESCRIPTION
This PR adds the MLflow service to the docker-compose.yaml file to facilitate machine learning experiment tracking and management. The MLflow service will run on port 5001 and is configured to be compatible with the current infrastructure.

Changes:
Added MLflow service configuration in docker-compose.yaml.
Ensured MLflow runs on the linux/amd64 platform for compatibility.
Configured MLflow to be accessible from outside the container.